### PR TITLE
Add safer defaults to install script

### DIFF
--- a/install_anydesk.sh
+++ b/install_anydesk.sh
@@ -3,6 +3,8 @@
 
 
 #!/usr/bin/env bash
+# Exit on errors, unset variables, or failed pipeline commands
+set -euo pipefail
 
 echo "🔧 Installing AnyDesk on Lync Hub..."
 


### PR DESCRIPTION
## Summary
- ensure `install_anydesk.sh` exits when encountering errors or unset variables

## Testing
- `bash -n install_anydesk.sh`


------
https://chatgpt.com/codex/tasks/task_e_68430c06d3c8832c8a807facee4c511d