### PR TITLE
Fix interactive prompts when running via curl

### DIFF
--- a/install_anydesk.sh
+++ b/install_anydesk.sh
@@ -38,8 +38,10 @@ fi
 
 # Set unattended access password
 echo
-read -s -p "Set AnyDesk unattended access password: " AD_PASS; echo
-read -s -p "Confirm password: " AD_PASS_CONFIRM; echo
+read -s -p "Set AnyDesk unattended access password: " AD_PASS < /dev/tty
+echo
+read -s -p "Confirm password: " AD_PASS_CONFIRM < /dev/tty
+echo
 
 if [[ "$AD_PASS" != "$AD_PASS_CONFIRM" ]]; then
   echo "❌ Passwords do not match."


### PR DESCRIPTION
## Summary
- ensure password prompts work when script is piped via `curl`

## Testing
- `bash -n install_anydesk.sh`


------
https://chatgpt.com/codex/tasks/task_e_68430b0ab938832cb723268fa32a335f