### PR TITLE
Add Docker install script and compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ curl -sSL https://raw.githubusercontent.com/LyncTaylor/lync-hub-setup/main/insta
 
 This script installs AnyDesk, prompts you to set an unattended access password,
 and reboots the system to apply the changes.
+
+## Installing Docker and base services
+
+Run the following command to install Docker and download the base `docker-compose.yml` file:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/LyncTaylor/lync-hub-setup/main/install_docker.sh | sudo bash -i
+```
+
+After the script finishes you can start the services with:
+
+```bash
+docker compose -f /opt/lync-hub/docker-compose.yml up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.8"
+services:
+  frigate:
+    image: blakeblackshear/frigate:stable
+    container_name: frigate
+    privileged: true
+    volumes:
+      - ./frigate/config:/config
+      - /etc/localtime:/etc/localtime:ro
+      - /dev/bus/usb:/dev/bus/usb
+    restart: unless-stopped
+
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: homeassistant
+    volumes:
+      - ./homeassistant/config:/config
+    restart: unless-stopped
+
+  mqtt:
+    image: eclipse-mosquitto:latest
+    container_name: mqtt
+    volumes:
+      - ./mosquitto/data:/mosquitto/data
+      - ./mosquitto/config:/mosquitto/config
+    restart: unless-stopped
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: cloudflared
+    command: tunnel run
+    restart: unless-stopped
+
+  watchdog:
+    image: containrrr/watchtower:latest
+    container_name: watchdog
+    command: --cleanup --interval 300
+    restart: unless-stopped

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run this command to execute this script from GitHub:
+#   curl -sSL https://raw.githubusercontent.com/LyncTaylor/lync-hub-setup/main/install_docker.sh | sudo bash -i
+
+set -e
+
+if [[ $EUID -ne 0 ]]; then
+  echo "❌ Please run this script with sudo."
+  exit 1
+fi
+
+echo "🔧 Installing Docker..."
+
+apt-get update
+apt-get install -y ca-certificates curl gnupg
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable docker
+systemctl start docker
+
+usermod -aG docker ${SUDO_USER:-$USER}
+
+mkdir -p /opt/lync-hub
+curl -fsSL https://raw.githubusercontent.com/LyncTaylor/lync-hub-setup/main/docker-compose.yml -o /opt/lync-hub/docker-compose.yml
+
+echo "✅ Docker installed. Compose file saved to /opt/lync-hub/docker-compose.yml"
+echo "Run 'docker compose -f /opt/lync-hub/docker-compose.yml up -d' to start services."


### PR DESCRIPTION
## Summary
- add script to install Docker and download compose file
- add compose file with Frigate, Home Assistant, MQTT, Cloudflare tunnel, and Watchtower containers
- document Docker installation in README

## Testing
- `git status --short`
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_68430f60e1e8832ca1a763e76bb418f6