### PR TITLE
Update compose version and remove watchdog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.9"
 services:
   frigate:
     image: blakeblackshear/frigate:stable
@@ -31,8 +31,3 @@ services:
     command: tunnel run
     restart: unless-stopped
 
-  watchdog:
-    image: containrrr/watchtower:latest
-    container_name: watchdog
-    command: --cleanup --interval 300
-    restart: unless-stopped


### PR DESCRIPTION
## Summary
- remove watchdog service from docker-compose
- update compose file version to 3.9

## Testing
- `docker compose version` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684311fd9b08832cafecefe7154d665c