### PR TITLE
Update Frigate config for Coral USB

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ After the script finishes you can start the services with:
 ```bash
 docker compose -f /opt/lync-hub/docker-compose.yml up -d
 ```
+
+The compose file expects a Frigate configuration in `frigate/config/config.yml`.
+The sample configuration is set up to use a Coral USB accelerator for detections.
+Clips and recordings are stored under `/opt/lync-hub/frigate/media`.
+Update the `FRIGATE_RTSP_PASSWORD` environment variable in the compose file with
+your RTSP password before starting the stack.
+
+Home Assistant's configuration will be stored under `/opt/lync-hub/homeassistant/config`.
+The container uses host networking and runs with `privileged` mode enabled for
+hardware access. Set the `TZ` environment variable in the compose file to your
+timezone before starting the stack.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,37 @@
 version: "3.9"
 services:
   frigate:
-    image: blakeblackshear/frigate:stable
+    image: ghcr.io/blakeblackshear/frigate:stable
     container_name: frigate
     privileged: true
+    network_mode: host
+    shm_size: "64mb"
+    environment:
+      TZ: "UTC"
+      FRIGATE_RTSP_PASSWORD: "changeme"
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
+      - /dev/dri/renderD128:/dev/dri/renderD128
     volumes:
       - ./frigate/config:/config
+      - /opt/lync-hub/frigate/media:/media/frigate
       - /etc/localtime:/etc/localtime:ro
-      - /dev/bus/usb:/dev/bus/usb
+      - type: tmpfs
+        target: /tmp/cache
+        tmpfs:
+          size: 256m
     restart: unless-stopped
 
   homeassistant:
     image: ghcr.io/home-assistant/home-assistant:stable
     container_name: homeassistant
+    privileged: true
+    network_mode: host
+    environment:
+      TZ: "UTC"
     volumes:
       - ./homeassistant/config:/config
+      - /etc/localtime:/etc/localtime:ro
     restart: unless-stopped
 
   mqtt:

--- a/frigate/config/config.yml
+++ b/frigate/config/config.yml
@@ -1,0 +1,9 @@
+mqtt:
+  host: mqtt
+  user: username
+  password: password
+detectors:
+  coral:
+    type: edgetpu
+    device: usb
+cameras: {}

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -29,8 +29,14 @@ systemctl start docker
 
 usermod -aG docker ${SUDO_USER:-$USER}
 
-mkdir -p /opt/lync-hub
+mkdir -p /opt/lync-hub/frigate/media \
+         /opt/lync-hub/frigate/config \
+         /opt/lync-hub/homeassistant/config \
+         /opt/lync-hub/mosquitto/data \
+         /opt/lync-hub/mosquitto/config
+
 curl -fsSL https://raw.githubusercontent.com/LyncTaylor/lync-hub-setup/main/docker-compose.yml -o /opt/lync-hub/docker-compose.yml
+curl -fsSL https://raw.githubusercontent.com/LyncTaylor/lync-hub-setup/main/frigate/config/config.yml -o /opt/lync-hub/frigate/config/config.yml
 
 echo "✅ Docker installed. Compose file saved to /opt/lync-hub/docker-compose.yml"
 echo "Run 'docker compose -f /opt/lync-hub/docker-compose.yml up -d' to start services."


### PR DESCRIPTION
## Summary
- note that the sample config uses a Coral USB accelerator
- configure detectors in `frigate/config.yml` for Coral
- run Home Assistant container with host networking and privileged mode

## Testing
- `bash -n install_docker.sh`
- `bash -n install_anydesk.sh`


------
https://chatgpt.com/codex/tasks/task_e_684312d1ff60832ca440044e2edf8160