### PR TITLE
Update frigate ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ The sample configuration is set up to use a Coral USB accelerator for detections
 Clips and recordings are stored under `/opt/lync-hub/frigate/media`.
 Update the `FRIGATE_RTSP_PASSWORD` environment variable in the compose file with
 your RTSP password before starting the stack.
+Frigate exposes ports `8971`, `5000`, `8554`, and `8555` for its web interface,
+RTSP, and WebRTC services.
 
 Home Assistant's configuration will be stored under `/opt/lync-hub/homeassistant/config`.
-The container uses host networking and runs with `privileged` mode enabled for
+Home Assistant uses host networking and runs with `privileged` mode enabled for
 hardware access. Set the `TZ` environment variable in the compose file to your
 timezone before starting the stack.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,12 @@ services:
     image: ghcr.io/blakeblackshear/frigate:stable
     container_name: frigate
     privileged: true
-    network_mode: host
+    ports:
+      - "8971:8971"
+      - "5000:5000" # Internal unauthenticated access. Expose carefully.
+      - "8554:8554" # RTSP feeds
+      - "8555:8555/tcp" # WebRTC over tcp
+      - "8555:8555/udp" # WebRTC over udp
     shm_size: "64mb"
     environment:
       TZ: "UTC"


### PR DESCRIPTION
## Summary
- map ports for frigate service instead of host networking
- document port mapping in README
- clarify that Home Assistant uses host networking

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68431e906470832ca1b699742692350d