### PR TITLE
Update compose for USB-only Frigate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       FRIGATE_RTSP_PASSWORD: "changeme"
     devices:
       - /dev/bus/usb:/dev/bus/usb
-      - /dev/dri/renderD128:/dev/dri/renderD128
     volumes:
       - ./frigate/config:/config
       - /opt/lync-hub/frigate/media:/media/frigate


### PR DESCRIPTION
## Summary
- remove GPU device mapping from Frigate docker-compose config

## Testing
- `docker compose -f docker-compose.yml config` *(fails: `bash: docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684322ee409c832ca84f18409ee771e6