### PR TITLE
Switch frigate to host networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ The sample configuration is set up to use a Coral USB accelerator for detections
 Clips and recordings are stored under `/opt/lync-hub/frigate/media`.
 Update the `FRIGATE_RTSP_PASSWORD` environment variable in the compose file with
 your RTSP password before starting the stack.
-Frigate exposes ports `8971`, `5000`, `8554`, and `8555` for its web interface,
-RTSP, and WebRTC services.
+Frigate now uses host networking. Its web interface is available on port `5000`
+of the host and the service also listens on ports `8971`, `8554`, and `8555` for
+RTSP and WebRTC.
 
 Home Assistant's configuration will be stored under `/opt/lync-hub/homeassistant/config`.
 Home Assistant uses host networking and runs with `privileged` mode enabled for

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,7 @@ services:
     image: ghcr.io/blakeblackshear/frigate:stable
     container_name: frigate
     privileged: true
-    ports:
-      - "8971:8971"
-      - "5000:5000" # Internal unauthenticated access. Expose carefully.
-      - "8554:8554" # RTSP feeds
-      - "8555:8555/tcp" # WebRTC over tcp
-      - "8555:8555/udp" # WebRTC over udp
+    network_mode: host
     shm_size: "64mb"
     environment:
       TZ: "UTC"


### PR DESCRIPTION
## Summary
- run frigate container in host networking mode
- document new host network configuration

## Testing
- `bash -n install_docker.sh`
- `bash -n install_anydesk.sh`
- `docker compose -f docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432409e038832cbead44d3e523ef83