### PR TITLE
Enable unattended AnyDesk setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ To install AnyDesk on a Lync hub in one step, run the following command:
 curl -sSL https://raw.githubusercontent.com/LyncTaylor/lync-hub-setup/main/install_anydesk.sh | sudo bash -i
 ```
 
-This script installs AnyDesk, prompts you to set an unattended access password,
-and reboots the system to apply the changes.
+This script installs AnyDesk and configures an unattended access password.
+Set the `ANYDESK_PASSWORD` environment variable before running the command to
+use a pre-defined password without any prompts. If the variable is unset, you
+will be asked to enter the password interactively. After installation the system
+reboots to apply the changes.
 
 ## Installing Docker and base services
 

--- a/install_anydesk.sh
+++ b/install_anydesk.sh
@@ -35,15 +35,19 @@ else
 fi
 
 # Set unattended access password
-echo
-read -s -p "Set AnyDesk unattended access password: " AD_PASS < /dev/tty
-echo
-read -s -p "Confirm password: " AD_PASS_CONFIRM < /dev/tty
-echo
-
-if [[ "$AD_PASS" != "$AD_PASS_CONFIRM" ]]; then
-  echo "❌ Passwords do not match."
-  exit 1
+if [[ -n ${ANYDESK_PASSWORD:-} ]]; then
+  AD_PASS="$ANYDESK_PASSWORD"
+else
+  echo
+  read -s -p "Set AnyDesk unattended access password: " AD_PASS < /dev/tty
+  echo
+  read -s -p "Confirm password: " AD_PASS_CONFIRM < /dev/tty
+  echo
+  if [[ "$AD_PASS" != "$AD_PASS_CONFIRM" ]]; then
+    echo "❌ Passwords do not match."
+    exit 1
+  fi
+  unset AD_PASS_CONFIRM
 fi
 
 if [[ ${#AD_PASS} -lt 8 ]]; then
@@ -52,7 +56,7 @@ if [[ ${#AD_PASS} -lt 8 ]]; then
 fi
 
 anydesk --set-password "$AD_PASS"
-unset AD_PASS AD_PASS_CONFIRM
+unset AD_PASS ANYDESK_PASSWORD
 
 # Show AnyDesk ID
 echo


### PR DESCRIPTION
## Summary
- allow providing the AnyDesk unattended access password via `ANYDESK_PASSWORD`
- document the new option in the readme

## Testing
- `bash -n install_anydesk.sh`

------
https://chatgpt.com/codex/tasks/task_e_684330fc41b4832c9cfe666c97f5c24b